### PR TITLE
Ability to add JSON-like output added.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
     
 setuptools.setup(
     name="python_heideltime",
-    version=1.0,
+    version="1.1",
     author="Philip Hausner",
     author_email="hausner@informatik.uni-heidelberg.de",
     description="Python wrapper for HeidelTime",
@@ -17,5 +17,5 @@ setuptools.setup(
         "License ;; OSI Approved :: GNU GPL",
         "Operating System :: Debian",
         ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     )

--- a/tests/test_Heideltime.py
+++ b/tests/test_Heideltime.py
@@ -1,0 +1,36 @@
+
+import unittest
+
+from python_heideltime import Heideltime
+
+
+class TestHeideltime(unittest.TestCase):
+
+    def test__convert_to_json(self):
+        heideltime = Heideltime()
+        heideltime.set_output_type('JSON')
+
+        self.assertEqual('TIMEML', heideltime.output_type)
+
+        test_text = 'Yesterday we drove to the mountains. Today we are going to the sea'
+
+        result = heideltime.parse(test_text)
+
+        expected_result = [
+            {
+                'tid': 't1',
+                'type': 'DATE',
+                'value': 'XXXX-XX-XX',
+                'text': 'Yesterday',
+                'char_pos': [0, 9]
+            },
+            {
+                'tid': 't2',
+                'type': 'DATE',
+                'value': 'PRESENT_REF',
+                'text': 'Today',
+                'char_pos': [37, 42]
+            }
+        ]
+
+        self.assertEqual(expected_result, result)


### PR DESCRIPTION
Instead of having to deal with cumbersome XML output, this only outputs the tags (and their information) to the users in a JSON-like object.
Aside from Heideltime's added attributes, I further added the temporal tag's text, as well as the absolute character position.

Three pointers that might be important to discuss here:
- Is it clear for users that this will in fact not be JSON (i.e., written as a .json file), and rather just return a Python dictionary?
- Is handling this through the `output_type` appropriate (instead of adding a separate option)?
- Note that this also introduces additional dependencies, which I am not sure how to best include in the setuptools. I am quite sure there was an option to automatically install them as necessary, will also add this, if wanted.