### PR TITLE
Extending the automatically installed languages.

### DIFF
--- a/install_heideltime_standalone.sh
+++ b/install_heideltime_standalone.sh
@@ -17,6 +17,12 @@ wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/
 wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/install-tagger.sh 
 wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/german.par.gz 
 wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/english.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/spanish.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/portuguese.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/dutch.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/italian.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french.par.gz
+wget --no-verbose https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/estonian.par.gz
 
 # install treetagger
 sh install-tagger.sh


### PR DESCRIPTION
Currently, only German and English are installed, however, with the same approach to the existing script, we can easily include 9 languages.
All of those simply have other language-specific files from the same URL space of the TreeTagger website, so I included those, too.
Note that this increases the overall installed size to ~240MB (for reference, only DE and EN together comprise of about 50MB space).